### PR TITLE
Refactoring code and implementing feedback

### DIFF
--- a/hbase/src/main/java/org/apache/metamodel/hbase/HBaseColumn.java
+++ b/hbase/src/main/java/org/apache/metamodel/hbase/HBaseColumn.java
@@ -18,14 +18,6 @@
  */
 package org.apache.metamodel.hbase;
 
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.ColumnTypeImpl;
 import org.apache.metamodel.schema.MutableColumn;
@@ -127,105 +119,5 @@ public final class HBaseColumn extends MutableColumn {
     @Override
     public String getQuote() {
         return null;
-    }
-
-    /**
-     * Creates a set of columnFamilies out of a list of hbaseColumns
-     * @param columns
-     * @return {@link LinkedHashSet}
-     */
-    public static Set<String> getColumnFamilies(List<HBaseColumn> columns) {
-        final LinkedHashSet<String> columnFamilies = new LinkedHashSet<>();
-        for (HBaseColumn column : columns) {
-            columnFamilies.add(column.getColumnFamily());
-        }
-        return columnFamilies;
-    }
-
-    /**
-     * Returns the index of the ID-column (see {@link HBaseDataContext#FIELD_ID}) in an array of HBaseColumns.
-     * When no ID-column is found, then null is returned.
-     * @param columns
-     * @return {@link Integer}
-     */
-    public static Integer findIndexOfIdColumn(List<HBaseColumn> columns) {
-        int i = 0;
-        Integer indexOfIDColumn = null;
-        Iterator<HBaseColumn> iterator = columns.iterator();
-        while (indexOfIDColumn == null && iterator.hasNext()) {
-            indexOfIDColumn = findIndexOfIdColumn(iterator.next().getColumnFamily(), i);
-            if (indexOfIDColumn == null) {
-                i++;
-            }
-        }
-        return indexOfIDColumn;
-    }
-
-    /**
-     * Returns the index of the ID-column (see {@link HBaseDataContext#FIELD_ID}) in an array of columnNames.
-     * When no ID-column is found, then null is returned.
-     * @param columnNames
-     * @return {@link Integer}
-     */
-    public static Integer findIndexOfIdColumn(String[] columnNames) {
-        int i = 0;
-        Integer indexOfIDColumn = null;
-        while (indexOfIDColumn == null && i < columnNames.length) {
-            indexOfIDColumn = findIndexOfIdColumn(columnNames[i], i);
-            if (indexOfIDColumn == null) {
-                i++;
-            }
-        }
-        return indexOfIDColumn;
-    }
-
-    /**
-     * Returns the index of the ID-column (see {@link HBaseDataContext#FIELD_ID})
-     * When no ID-column is found, then null is returned.
-     * @param columnNames
-     * @return {@link Integer}
-     */
-    private static Integer findIndexOfIdColumn(String columnName, int index) {
-        Integer indexOfIDColumn = null;
-        if (columnName.equals(HBaseDataContext.FIELD_ID)) {
-            indexOfIDColumn = new Integer(index);
-        }
-        return indexOfIDColumn;
-    }
-
-    /**
-     * Converts a list of {@link Column}'s to a list of {@link HBaseColumn}'s
-     * @param columns
-     * @return {@link List}<{@link HBaseColumn}>
-     */
-    public static List<HBaseColumn> convertToHBaseColumnsList(List<Column> columns) {
-        return columns.stream().map(column -> (HBaseColumn) column).collect(Collectors.toList());
-    }
-
-    /**
-     * Converts a list of {@link HBaseColumn}'s to a list of {@link Column}'s
-     * @param columns
-     * @return {@link List}<{@link Column}>
-     */
-    public static List<Column> convertToColumnsList(List<HBaseColumn> columns) {
-        return columns.stream().map(column -> (Column) column).collect(Collectors.toList());
-    }
-
-    /**
-     * Converts a list of {@link HBaseColumn}'s to an array of {@link HBaseColumn}'s
-     * @param columns
-     * @return Array of {@link HBaseColumn}
-     */
-    public static HBaseColumn[] convertToHBaseColumnsArray(List<HBaseColumn> columns) {
-        return columns.stream().map(column -> column).toArray(size -> new HBaseColumn[size]);
-    }
-
-    /**
-     * Converts a array of {@link Column}'s to an array of {@link HBaseColumn}'s
-     * @param columns
-     * @return Array of {@link HBaseColumn}
-     */
-    public static HBaseColumn[] convertToHBaseColumnsArray(Column[] columns) {
-        return Arrays.stream(columns).map(column -> (HBaseColumn) column).toArray(size -> new HBaseColumn[size]);
     }
 }

--- a/hbase/src/main/java/org/apache/metamodel/hbase/HBaseUpdateCallback.java
+++ b/hbase/src/main/java/org/apache/metamodel/hbase/HBaseUpdateCallback.java
@@ -37,13 +37,13 @@ public class HBaseUpdateCallback extends AbstractUpdateCallback implements Updat
 
     private final HBaseClient _hBaseClient;
 
-    public HBaseUpdateCallback(HBaseDataContext dataContext) {
+    public HBaseUpdateCallback(final HBaseDataContext dataContext) {
         super(dataContext);
         _hBaseClient = new HBaseClient(dataContext.getConnection());
     }
 
     @Override
-    public TableCreationBuilder createTable(Schema schema, String name) {
+    public TableCreationBuilder createTable(final Schema schema, final String name) {
         return new HBaseCreateTableBuilder(this, schema, name);
     }
 
@@ -54,7 +54,8 @@ public class HBaseUpdateCallback extends AbstractUpdateCallback implements Updat
      * @param columnFamilies the columnFamilies of the new table
      * @return {@link HBaseCreateTableBuilder}
      */
-    public HBaseCreateTableBuilder createTable(Schema schema, String name, Set<String> columnFamilies) {
+    public HBaseCreateTableBuilder createTable(final Schema schema, final String name,
+            final Set<String> columnFamilies) {
         return new HBaseCreateTableBuilder(this, schema, name, columnFamilies);
     }
 
@@ -64,7 +65,7 @@ public class HBaseUpdateCallback extends AbstractUpdateCallback implements Updat
     }
 
     @Override
-    public TableDropBuilder dropTable(Table table) {
+    public TableDropBuilder dropTable(final Table table) {
         return new HBaseTableDropBuilder(table, this);
     }
 
@@ -78,7 +79,7 @@ public class HBaseUpdateCallback extends AbstractUpdateCallback implements Updat
     }
 
     /**
-     * Initiates the building of a row insertion operation. 
+     * Initiates the building of a row insertion operation.
      * @param table Table to get inserts.
      * @param columns List of {@link HBaseColumn} to insert on.
      * @return {@link HBaseRowInsertionBuilder}
@@ -89,7 +90,7 @@ public class HBaseUpdateCallback extends AbstractUpdateCallback implements Updat
             throw new IllegalArgumentException("The hbaseColumns list is null or empty");
         }
         if (table instanceof HBaseTable) {
-            return new HBaseRowInsertionBuilder(this, (HBaseTable) table, HBaseColumn.convertToColumnsList(columns));
+            return new HBaseRowInsertionBuilder(this, (HBaseTable) table, columns);
         } else {
             throw new IllegalArgumentException("Not an HBase table: " + table);
         }
@@ -104,9 +105,9 @@ public class HBaseUpdateCallback extends AbstractUpdateCallback implements Updat
      * @throws IllegalArgumentException when table isn't a {@link HBaseTable}
      */
     @Override
-    public RowDeletionBuilder deleteFrom(Table table) {
+    public RowDeletionBuilder deleteFrom(final Table table) {
         if (table instanceof HBaseTable) {
-            return new HBaseRowDeletionBuilder(_hBaseClient, (HBaseTable) table);
+            return new HBaseRowDeletionBuilder(_hBaseClient, table);
         } else {
             throw new IllegalArgumentException("Not an HBase table: " + table);
         }

--- a/hbase/src/test/java/org/apache/metamodel/hbase/CreateTableTest.java
+++ b/hbase/src/test/java/org/apache/metamodel/hbase/CreateTableTest.java
@@ -20,7 +20,9 @@ package org.apache.metamodel.hbase;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.schema.ImmutableSchema;
@@ -116,7 +118,7 @@ public class CreateTableTest extends HBaseUpdateCallbackTest {
         if (isConfigured()) {
             final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
             final LinkedHashMap<HBaseColumn, Object> row = createRow(table, null, CF_FOO, CF_BAR);
-            final Set<String> columnFamilies = HBaseColumn.getColumnFamilies(getHBaseColumnsFromMap(row));
+            final Set<String> columnFamilies = getColumnFamilies(getHBaseColumnsFromMap(row));
             try {
                 final HBaseCreateTableBuilder hBaseCreateTableBuilder = (HBaseCreateTableBuilder) getUpdateCallback()
                         .createTable(getSchema(), TABLE_NAME);
@@ -194,7 +196,7 @@ public class CreateTableTest extends HBaseUpdateCallbackTest {
         if (isConfigured()) {
             final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
             final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
-            final Set<String> columnFamilies = HBaseColumn.getColumnFamilies(getHBaseColumnsFromMap(row));
+            final Set<String> columnFamilies = getColumnFamilies(getHBaseColumnsFromMap(row));
             try {
                 final HBaseCreateTableBuilder hBaseCreateTableBuilder = (HBaseCreateTableBuilder) getUpdateCallback()
                         .createTable(getSchema(), TABLE_NAME);
@@ -218,7 +220,7 @@ public class CreateTableTest extends HBaseUpdateCallbackTest {
         if (isConfigured()) {
             final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
             final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
-            final Set<String> columnFamilies = HBaseColumn.getColumnFamilies(getHBaseColumnsFromMap(row));
+            final Set<String> columnFamilies = getColumnFamilies(getHBaseColumnsFromMap(row));
             try {
                 getUpdateCallback().createTable(getSchema(), TABLE_NAME, columnFamilies).execute();
                 checkSuccesfullyInsertedTable();
@@ -229,5 +231,15 @@ public class CreateTableTest extends HBaseUpdateCallbackTest {
             warnAboutANotExecutedTest(getClass().getName(), new Object() {
             }.getClass().getEnclosingMethod().getName());
         }
+    }
+
+    /**
+     * Creates a set of columnFamilies out of a list of hbaseColumns
+     *
+     * @param columns
+     * @return {@link LinkedHashSet}
+     */
+    private static Set<String> getColumnFamilies(List<HBaseColumn> columns) {
+        return columns.stream().map(HBaseColumn::getColumnFamily).distinct().collect(Collectors.toSet());
     }
 }

--- a/hbase/src/test/java/org/apache/metamodel/hbase/InsertRowTest.java
+++ b/hbase/src/test/java/org/apache/metamodel/hbase/InsertRowTest.java
@@ -24,7 +24,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.apache.metamodel.MetaModelException;
-import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.MutableTable;
 
 public class InsertRowTest extends HBaseUpdateCallbackTest {
@@ -135,7 +134,7 @@ public class InsertRowTest extends HBaseUpdateCallbackTest {
             try {
                 final HBaseTable existingTable = createAndInsertTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
                         CF_BAR);
-                List<Column> emptyList = new ArrayList<>();
+                List<HBaseColumn> emptyList = new ArrayList<>();
                 new HBaseRowInsertionBuilder(getUpdateCallback(), existingTable, emptyList);
                 fail("Should get an exception that the columns list is empty.");
             } catch (IllegalArgumentException e) {
@@ -258,7 +257,7 @@ public class InsertRowTest extends HBaseUpdateCallbackTest {
                 final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
                 final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO,
                         CF_BAR);
-                final HBaseColumn[] columns = HBaseColumn.convertToHBaseColumnsArray(getHBaseColumnsFromMap(row));
+                final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromMap(row));
                 final Object[] values = new String[] { "Values" };
                 new HBaseClient(getDataContext().getConnection()).insertRow(null, columns, values, 0);
                 fail("Should get an exception that tableName is null");
@@ -302,7 +301,7 @@ public class InsertRowTest extends HBaseUpdateCallbackTest {
                 final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
                 final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO,
                         CF_BAR);
-                final HBaseColumn[] columns = HBaseColumn.convertToHBaseColumnsArray(getHBaseColumnsFromMap(row));
+                final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromMap(row));
                 new HBaseClient(getDataContext().getConnection()).insertRow(table.getName(), columns, null, 0);
                 fail("Should get an exception that values is null");
             } catch (IllegalArgumentException e) {
@@ -325,7 +324,7 @@ public class InsertRowTest extends HBaseUpdateCallbackTest {
                 final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
                 final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO,
                         CF_BAR);
-                final HBaseColumn[] columns = HBaseColumn.convertToHBaseColumnsArray(getHBaseColumnsFromMap(row));
+                final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromMap(row));
                 final Object[] values = new String[] { "Values" };
                 new HBaseClient(getDataContext().getConnection()).insertRow(table.getName(), columns, values, 10);
                 fail("Should get an exception that the indexOfIdColumn is incorrect");
@@ -349,7 +348,7 @@ public class InsertRowTest extends HBaseUpdateCallbackTest {
                 final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
                 final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO,
                         CF_BAR);
-                final HBaseColumn[] columns = HBaseColumn.convertToHBaseColumnsArray(getHBaseColumnsFromMap(row));
+                final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromMap(row));
                 final Object[] values = new String[] { null };
                 new HBaseClient(getDataContext().getConnection()).insertRow(table.getName(), columns, values, 0);
                 fail("Should get an exception that the indexOfIdColumn is incorrect");
@@ -437,4 +436,15 @@ public class InsertRowTest extends HBaseUpdateCallbackTest {
             }.getClass().getEnclosingMethod().getName());
         }
     }
+
+    /**
+     * Converts a list of {@link HBaseColumn}'s to an array of {@link HBaseColumn}'s
+     *
+     * @param columns
+     * @return Array of {@link HBaseColumn}
+     */
+    private static HBaseColumn[] convertToHBaseColumnsArray(List<HBaseColumn> columns) {
+        return columns.toArray(new HBaseColumn[columns.size()]);
+    }
+
 }


### PR DESCRIPTION
- Where missing, I added final qualifiers to method parameters.
- Moved static methods around to more logic locations. From my point of view the HBaseColumn class is not a Helper class to provide those.
- Changed the signature of the HBaseRowInsertionBuilder constructor, so it take a List of HBaseColumn object as a parameter, this makes it possible to remove a few of the Helper methods which cast List<HBaseColumn> to List<Column> and vice versa.
- Refactored the logic which looks up the id column in an array or list.
- Removed the "public" getHBaseColumnsInternal() method from HBaseTable, which essentially was only invoked in combination with a static getColumnFamilies method. Instead I added a getColumnFamilies() method to the HBaseTable class which return the column families for that HBase table.