### PR TITLE
Refactored to remove boiler plate isConfigured checks

### DIFF
--- a/hbase/src/test/java/org/apache/metamodel/hbase/CreateTableTest.java
+++ b/hbase/src/test/java/org/apache/metamodel/hbase/CreateTableTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.hbase;
 
+import static org.junit.Assert.*;
+
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -27,211 +29,169 @@ import java.util.stream.Collectors;
 
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.schema.ImmutableSchema;
+import org.junit.Test;
 
 public class CreateTableTest extends HBaseUpdateCallbackTest {
 
     /**
      * Check if creating table is supported
      */
+    @Test
     public void testCreateTableSupported() {
-        if (isConfigured()) {
-            assertTrue(getUpdateCallback().isCreateTableSupported());
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
-        }
+        assertTrue(getUpdateCallback().isCreateTableSupported());
     }
 
     /**
      * Create a table with an immutableSchema, should throw a IllegalArgumentException
      */
+    @Test
     public void testWrongSchema() {
-        if (isConfigured()) {
-            final ImmutableSchema immutableSchema = new ImmutableSchema(getSchema());
-            try {
-                getUpdateCallback().createTable(immutableSchema, TABLE_NAME).execute();
-                fail("Should get an exception that the schema isn't mutable");
-            } catch (IllegalArgumentException e) {
-                assertEquals("Not a mutable schema: " + immutableSchema, e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        final ImmutableSchema immutableSchema = new ImmutableSchema(getSchema());
+        try {
+            getUpdateCallback().createTable(immutableSchema, TABLE_NAME).execute();
+            fail("Should get an exception that the schema isn't mutable");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Not a mutable schema: " + immutableSchema, e.getMessage());
         }
     }
 
     /**
      * Create a table without columnFamilies, should throw a MetaModelException
      */
+    @Test
     public void testCreateTableWithoutColumnFamilies() {
-        if (isConfigured()) {
-            try {
-                getUpdateCallback().createTable(getSchema(), TABLE_NAME).execute();
-                fail("Should get an exception that the columnFamilies haven't been set");
-            } catch (MetaModelException e) {
-                assertEquals("Creating a table without columnFamilies", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            getUpdateCallback().createTable(getSchema(), TABLE_NAME).execute();
+            fail("Should get an exception that the columnFamilies haven't been set");
+        } catch (MetaModelException e) {
+            assertEquals("Creating a table without columnFamilies", e.getMessage());
         }
     }
 
     /**
      * Create a table with columnFamilies null, should throw a MetaModelException
      */
+    @Test
     public void testColumnFamiliesNull() {
-        if (isConfigured()) {
-            try {
-                getUpdateCallback().createTable(getSchema(), TABLE_NAME, null).execute();
-                fail("Should get an exception that the columnFamilies haven't been set");
-            } catch (MetaModelException e) {
-                assertEquals("Creating a table without columnFamilies", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            getUpdateCallback().createTable(getSchema(), TABLE_NAME, null).execute();
+            fail("Should get an exception that the columnFamilies haven't been set");
+        } catch (MetaModelException e) {
+            assertEquals("Creating a table without columnFamilies", e.getMessage());
         }
     }
 
     /**
      * Create a table with columnFamilies empty, should throw a MetaModelException
      */
+    @Test
     public void testColumnFamiliesEmpty() {
-        if (isConfigured()) {
-            try {
-                final LinkedHashSet<String> columnFamilies = new LinkedHashSet<String>();
-                getUpdateCallback().createTable(getSchema(), TABLE_NAME, columnFamilies).execute();
-                fail("Should get an exception that the columnFamilies haven't been set");
-            } catch (MetaModelException e) {
-                assertEquals("Creating a table without columnFamilies", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final LinkedHashSet<String> columnFamilies = new LinkedHashSet<String>();
+            getUpdateCallback().createTable(getSchema(), TABLE_NAME, columnFamilies).execute();
+            fail("Should get an exception that the columnFamilies haven't been set");
+        } catch (MetaModelException e) {
+            assertEquals("Creating a table without columnFamilies", e.getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the tableName null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithTableNameNull() {
-        if (isConfigured()) {
-            try {
-                final LinkedHashSet<String> columnFamilies = new LinkedHashSet<>();
-                columnFamilies.add("1");
-                new HBaseClient(getDataContext().getConnection()).createTable(null, columnFamilies);
-                fail("Should get an exception that tableName is null");
-            } catch (IllegalArgumentException e) {
-                assertEquals("Can't create a table without having the tableName or columnFamilies", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final LinkedHashSet<String> columnFamilies = new LinkedHashSet<>();
+            columnFamilies.add("1");
+            new HBaseClient(getDataContext().getConnection()).createTable(null, columnFamilies);
+            fail("Should get an exception that tableName is null");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't create a table without having the tableName or columnFamilies", e.getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the tableName null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithColumnFamiliesNull() {
-        if (isConfigured()) {
-            try {
-                new HBaseClient(getDataContext().getConnection()).createTable("1", null);
-                fail("Should get an exception that columnFamilies is null");
-            } catch (IllegalArgumentException e) {
-                assertEquals("Can't create a table without having the tableName or columnFamilies", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            new HBaseClient(getDataContext().getConnection()).createTable("1", null);
+            fail("Should get an exception that columnFamilies is null");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't create a table without having the tableName or columnFamilies", e.getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the tableName null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithColumnFamiliesEmpty() {
-        if (isConfigured()) {
-            try {
-                final LinkedHashSet<String> columnFamilies = new LinkedHashSet<>();
-                new HBaseClient(getDataContext().getConnection()).createTable("1", columnFamilies);
-                fail("Should get an exception that columnFamilies is empty");
-            } catch (IllegalArgumentException e) {
-                assertEquals("Can't create a table without having the tableName or columnFamilies", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final LinkedHashSet<String> columnFamilies = new LinkedHashSet<>();
+            new HBaseClient(getDataContext().getConnection()).createTable("1", columnFamilies);
+            fail("Should get an exception that columnFamilies is empty");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't create a table without having the tableName or columnFamilies", e.getMessage());
         }
     }
 
     /**
      * Goodflow. Create a table without the ID-Column, should work
-     * @throws IOException 
+     *
+     * @throws IOException
      */
+    @Test
     public void testCreateTableWithoutIDColumn() throws IOException {
-        if (isConfigured()) {
-            final HBaseTable table = createHBaseTable(TABLE_NAME, null, CF_FOO, CF_BAR, null);
-            final LinkedHashMap<HBaseColumn, Object> row = createRow(table, null, CF_FOO, CF_BAR);
-            final Set<String> columnFamilies = getColumnFamilies(getHBaseColumnsFromRow(row));
-            try {
-                final HBaseCreateTableBuilder hBaseCreateTableBuilder = (HBaseCreateTableBuilder) getUpdateCallback()
-                        .createTable(getSchema(), TABLE_NAME);
+        final HBaseTable table = createHBaseTable(TABLE_NAME, null, CF_FOO, CF_BAR, null);
+        final LinkedHashMap<HBaseColumn, Object> row = createRow(table, null, CF_FOO, CF_BAR);
+        final Set<String> columnFamilies = getColumnFamilies(getHBaseColumnsFromRow(row));
+        try {
+            final HBaseCreateTableBuilder hBaseCreateTableBuilder = (HBaseCreateTableBuilder) getUpdateCallback()
+                    .createTable(getSchema(), TABLE_NAME);
 
-                hBaseCreateTableBuilder.setColumnFamilies(columnFamilies);
-                hBaseCreateTableBuilder.execute();
-                checkSuccesfullyInsertedTable();
-            } catch (Exception e) {
-                fail("Should not get an exception (that the ID-column is missing)");
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+            hBaseCreateTableBuilder.setColumnFamilies(columnFamilies);
+            hBaseCreateTableBuilder.execute();
+            checkSuccesfullyInsertedTable();
+        } catch (Exception e) {
+            fail("Should not get an exception (that the ID-column is missing)");
         }
     }
 
     /**
      * Goodflow. Create a table including the ID-Column (columnFamilies not in constructor), should work
      */
+    @Test
     public void testSettingColumnFamiliesAfterConstrutor() {
-        if (isConfigured()) {
-            final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
-            final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
-            final Set<String> columnFamilies = getColumnFamilies(getHBaseColumnsFromRow(row));
-            try {
-                final HBaseCreateTableBuilder hBaseCreateTableBuilder = (HBaseCreateTableBuilder) getUpdateCallback()
-                        .createTable(getSchema(), TABLE_NAME);
+        final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
+        final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
+        final Set<String> columnFamilies = getColumnFamilies(getHBaseColumnsFromRow(row));
+        try {
+            final HBaseCreateTableBuilder hBaseCreateTableBuilder = (HBaseCreateTableBuilder) getUpdateCallback()
+                    .createTable(getSchema(), TABLE_NAME);
 
-                hBaseCreateTableBuilder.setColumnFamilies(columnFamilies);
-                hBaseCreateTableBuilder.execute();
-                checkSuccesfullyInsertedTable();
-            } catch (Exception e) {
-                fail("Should not get an exception");
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+            hBaseCreateTableBuilder.setColumnFamilies(columnFamilies);
+            hBaseCreateTableBuilder.execute();
+            checkSuccesfullyInsertedTable();
+        } catch (Exception e) {
+            fail("Should not get an exception");
         }
     }
 
     /**
      * Goodflow. Create a table including the ID-Column (columnFamilies in constructor), should work
      */
+    @Test
     public void testCreateTableColumnFamiliesInConstrutor() {
-        if (isConfigured()) {
-            final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
-            final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
-            final Set<String> columnFamilies = getColumnFamilies(getHBaseColumnsFromRow(row));
-            try {
-                getUpdateCallback().createTable(getSchema(), TABLE_NAME, columnFamilies).execute();
-                checkSuccesfullyInsertedTable();
-            } catch (Exception e) {
-                fail("Should not get an exception");
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
+        final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
+        final Set<String> columnFamilies = getColumnFamilies(getHBaseColumnsFromRow(row));
+        try {
+            getUpdateCallback().createTable(getSchema(), TABLE_NAME, columnFamilies).execute();
+            checkSuccesfullyInsertedTable();
+        } catch (Exception e) {
+            fail("Should not get an exception");
         }
     }
 

--- a/hbase/src/test/java/org/apache/metamodel/hbase/DeleteRowTest.java
+++ b/hbase/src/test/java/org/apache/metamodel/hbase/DeleteRowTest.java
@@ -18,196 +18,164 @@
  */
 package org.apache.metamodel.hbase;
 
+import static org.junit.Assert.*;
+
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.schema.MutableTable;
+import org.junit.Test;
 
 public class DeleteRowTest extends HBaseUpdateCallbackTest {
 
     /**
      * Delete is supported
      */
+    @Test
     public void testDeleteSupported() {
-        if (isConfigured()) {
-            assertTrue(getUpdateCallback().isDeleteSupported());
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
-        }
+        assertTrue(getUpdateCallback().isDeleteSupported());
     }
 
     /**
      * Having the table type wrong, should throw an exception
      */
+    @Test
     public void testTableWrongType() {
-        if (isConfigured()) {
-            final MutableTable mutableTable = new MutableTable();
-            try {
-                getUpdateCallback().deleteFrom(mutableTable);
-                fail("Should get an exception that the type of the table is wrong.");
-            } catch (IllegalArgumentException e) {
-                assertEquals("Not an HBase table: " + mutableTable, e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        final MutableTable mutableTable = new MutableTable();
+        try {
+            getUpdateCallback().deleteFrom(mutableTable);
+            fail("Should get an exception that the type of the table is wrong.");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Not an HBase table: " + mutableTable, e.getMessage());
         }
     }
 
     /**
      * Creating a HBaseRowDeletionBuilder with the hBaseClient null, should throw an exception
-     * @throws IOException 
+     *
+     * @throws IOException
      */
+    @Test
     public void testHBaseClientNullAtBuilder() throws IOException {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                new HBaseRowDeletionBuilder(null, existingTable);
-                fail("Should get an exception that hBaseClient can't be null.");
-            } catch (IllegalArgumentException e) {
-                assertEquals("hBaseClient cannot be null", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            new HBaseRowDeletionBuilder(null, existingTable);
+            fail("Should get an exception that hBaseClient can't be null.");
+        } catch (IllegalArgumentException e) {
+            assertEquals("hBaseClient cannot be null", e.getMessage());
         }
     }
 
     /**
      * Not setting the rowkey, should throw an exception
-     * @throws IOException 
+     *
+     * @throws IOException
      */
+    @Test
     public void testNotSettingRowkey() throws IOException {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                getUpdateCallback().deleteFrom(existingTable).execute();
-                fail("Should get an exception that the columnFamily doesn't exist.");
-            } catch (MetaModelException e) {
-                assertEquals("Key cannot be null", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            getUpdateCallback().deleteFrom(existingTable).execute();
+            fail("Should get an exception that the columnFamily doesn't exist.");
+        } catch (MetaModelException e) {
+            assertEquals("Key cannot be null", e.getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the tableName null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithTableNameNull() {
-        if (isConfigured()) {
-            try {
-                new HBaseClient(getDataContext().getConnection()).deleteRow(null, new String("1"));
-                fail("Should get an exception that tableName is null");
-            } catch (IllegalArgumentException e) {
-                assertEquals("Can't delete a row without having tableName or rowKey", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            new HBaseClient(getDataContext().getConnection()).deleteRow(null, new String("1"));
+            fail("Should get an exception that tableName is null");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't delete a row without having tableName or rowKey", e.getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the rowKey null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithRowKeyNull() {
-        if (isConfigured()) {
-            try {
-                new HBaseClient(getDataContext().getConnection()).deleteRow("tableName", null);
-                fail("Should get an exception that rowKey is null");
-            } catch (IllegalArgumentException e) {
-                assertEquals("Can't delete a row without having tableName or rowKey", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            new HBaseClient(getDataContext().getConnection()).deleteRow("tableName", null);
+            fail("Should get an exception that rowKey is null");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't delete a row without having tableName or rowKey", e.getMessage());
         }
     }
 
     /**
      * Goodflow. Deleting a row, that doesn't exist, should not throw an exception
      */
+    @Test
     public void testDeletingNotExistingRow() {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
 
-                checkRows(false);
-                final HBaseRowDeletionBuilder rowDeletionBuilder = (HBaseRowDeletionBuilder) getUpdateCallback()
-                        .deleteFrom(existingTable);
-                rowDeletionBuilder.setKey(RK_1);
-                rowDeletionBuilder.execute();
-                checkRows(false);
-            } catch (Exception e) {
-                fail("Should not get an exception that the row doesn't exist.");
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+            checkRows(false);
+            final HBaseRowDeletionBuilder rowDeletionBuilder = (HBaseRowDeletionBuilder) getUpdateCallback().deleteFrom(
+                    existingTable);
+            rowDeletionBuilder.setKey(RK_1);
+            rowDeletionBuilder.execute();
+            checkRows(false);
+        } catch (Exception e) {
+            fail("Should not get an exception that the row doesn't exist.");
         }
     }
 
     /**
      * Goodflow. Deleting a row, which has an empty rowKey value, should not throw an exception
      */
+    @Test
     public void testUsingAnEmptyRowKeyValue() {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
 
-                checkRows(false);
-                final HBaseRowDeletionBuilder rowDeletionBuilder = (HBaseRowDeletionBuilder) getUpdateCallback()
-                        .deleteFrom(existingTable);
-                rowDeletionBuilder.setKey("");
-                rowDeletionBuilder.execute();
-                checkRows(false);
-            } catch (Exception e) {
-                fail("Should not get an exception that the rowkey is empty.");
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+            checkRows(false);
+            final HBaseRowDeletionBuilder rowDeletionBuilder = (HBaseRowDeletionBuilder) getUpdateCallback().deleteFrom(
+                    existingTable);
+            rowDeletionBuilder.setKey("");
+            rowDeletionBuilder.execute();
+            checkRows(false);
+        } catch (Exception e) {
+            fail("Should not get an exception that the rowkey is empty.");
         }
     }
 
     /**
      * Goodflow. Deleting a row succesfully.
      */
+    @Test
     public void testDeleteRowSuccesfully() {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
 
-                checkRows(false);
-                final HBaseRowInsertionBuilder rowInsertionBuilder = getUpdateCallback().insertInto(existingTable,
-                        columns);
-                setValuesInInsertionBuilder(row, rowInsertionBuilder);
-                rowInsertionBuilder.execute();
-                checkRows(true);
-                final HBaseRowDeletionBuilder rowDeletionBuilder = (HBaseRowDeletionBuilder) getUpdateCallback()
-                        .deleteFrom(existingTable);
-                rowDeletionBuilder.setKey(RK_1);
-                rowDeletionBuilder.execute();
-                checkRows(false);
-            } catch (Exception e) {
-                fail("Should not get an exception on deleting a row.");
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+            checkRows(false);
+            final HBaseRowInsertionBuilder rowInsertionBuilder = getUpdateCallback().insertInto(existingTable, columns);
+            setValuesInInsertionBuilder(row, rowInsertionBuilder);
+            rowInsertionBuilder.execute();
+            checkRows(true);
+            final HBaseRowDeletionBuilder rowDeletionBuilder = (HBaseRowDeletionBuilder) getUpdateCallback().deleteFrom(
+                    existingTable);
+            rowDeletionBuilder.setKey(RK_1);
+            rowDeletionBuilder.execute();
+            checkRows(false);
+        } catch (Exception e) {
+            fail("Should not get an exception on deleting a row.");
         }
     }
 }

--- a/hbase/src/test/java/org/apache/metamodel/hbase/DropTableTest.java
+++ b/hbase/src/test/java/org/apache/metamodel/hbase/DropTableTest.java
@@ -18,31 +18,30 @@
  */
 package org.apache.metamodel.hbase;
 
+import static org.junit.Assert.*;
+
 import java.io.IOException;
 
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.metamodel.MetaModelException;
+import org.junit.Test;
 
 public class DropTableTest extends HBaseUpdateCallbackTest {
 
     /**
      * Check if drop table is supported
      */
+    @Test
     public void testDropTableSupported() {
-        if (isConfigured()) {
             assertTrue(getUpdateCallback().isDropTableSupported());
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
-        }
     }
 
     /**
      * Trying to drop a table, that doesn't exist in the datastore, should throw a exception
      */
+    @Test
     public void testDropTableThatDoesntExist() {
-        if (isConfigured()) {
             try {
                 final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
                 getUpdateCallback().dropTable(table).execute();
@@ -50,35 +49,27 @@ public class DropTableTest extends HBaseUpdateCallbackTest {
             } catch (MetaModelException e) {
                 assertEquals("Trying to delete a table that doesn't exist in the datastore.", e.getMessage());
             }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
-        }
     }
 
     /**
      * Creating a HBaseClient with the tableName null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithTableNameNull() {
-        if (isConfigured()) {
             try {
                 new HBaseClient(getDataContext().getConnection()).dropTable(null);
                 fail("Should get an exception that tableName is null");
             } catch (IllegalArgumentException e) {
                 assertEquals("Can't drop a table without having the tableName", e.getMessage());
             }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
-        }
     }
 
     /**
      * Goodflow. Droping a table succesfully.
      * @throws IOException
      */
+    @Test
     public void testDropTableSuccesfully() throws IOException {
-        if (isConfigured()) {
             try {
                 final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
                         CF_BAR);
@@ -89,9 +80,5 @@ public class DropTableTest extends HBaseUpdateCallbackTest {
             } catch (Exception e) {
                 fail("Should not get an exception that the table doesn't exist in the datastore");
             }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
-        }
     }
 }

--- a/hbase/src/test/java/org/apache/metamodel/hbase/HBaseDataContextTest.java
+++ b/hbase/src/test/java/org/apache/metamodel/hbase/HBaseDataContextTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.hbase;
 
+import static org.junit.Assert.*;
+
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -30,23 +32,20 @@ import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.util.SimpleTableDef;
+import org.junit.Before;
+import org.junit.Test;
 
 public class HBaseDataContextTest extends HBaseTestCase {
 
     @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         super.setUp();
-        if (isConfigured()) {
-            createTableNatively();
-        }
+        createTableNatively();
     }
 
+    @Test
     public void testCreateInsertQueryAndDrop() throws Exception {
-        if (!isConfigured()) {
-            System.err.println(getInvalidConfigurationMessage());
-            return;
-        }
-
         // test the schema exploration
         final Table table = getDataContext().getDefaultSchema().getTableByName(TABLE_NAME);
         assertNotNull(table);

--- a/hbase/src/test/java/org/apache/metamodel/hbase/HBaseUpdateCallbackTest.java
+++ b/hbase/src/test/java/org/apache/metamodel/hbase/HBaseUpdateCallbackTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.hbase;
 
+import static org.junit.Assert.*;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -33,6 +35,8 @@ import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.MutableSchema;
 import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.util.SimpleTableDef;
+import org.junit.After;
+import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,46 +47,37 @@ public abstract class HBaseUpdateCallbackTest extends HBaseTestCase {
     private HBaseUpdateCallback updateCallback;
     private MutableSchema schema;
 
-    private static boolean warningGiven = false;
-
     @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         super.setUp();
-        if (isConfigured()) {
-            updateCallback = new HBaseUpdateCallback(getDataContext());
-            schema = (MutableSchema) getDataContext().getDefaultSchema();
-            dropTableIfItExists();
-        } else {
-            if (!warningGiven) {
-                System.err.println(getInvalidConfigurationMessage());
-                warningGiven = true;
-            }
-        }
+        updateCallback = new HBaseUpdateCallback(getDataContext());
+        schema = (MutableSchema) getDataContext().getDefaultSchema();
+        dropTableIfItExists();
     }
 
-    @Override
+    @After
     public void tearDown() throws Exception {
-        if (isConfigured()) {
-            dropTableIfItExists();
-        }
-        super.tearDown();
+        dropTableIfItExists();
     }
 
     /**
-     * Drop the table if it exists. 
+     * Drop the table if it exists.
      * After that check in the schema and the datastore if the actions have been executed succesfully.
      */
     protected void dropTableIfItExists() {
-        final Table table = schema.getTableByName(TABLE_NAME);
-        if (table != null) {
-            updateCallback.dropTable(table).execute();
-            // Check schema
-            assertNull(schema.getTableByName(TABLE_NAME));
-            // Check in the datastore
-            try (final Admin admin = getDataContext().getAdmin()) {
-                assertFalse(admin.tableExists(TableName.valueOf(TABLE_NAME)));
-            } catch (IOException e) {
-                fail("Should not an exception checking if the table exists");
+        if (schema != null) {
+            final Table table = schema.getTableByName(TABLE_NAME);
+            if (table != null) {
+                updateCallback.dropTable(table).execute();
+                // Check schema
+                assertNull(schema.getTableByName(TABLE_NAME));
+                // Check in the datastore
+                try (final Admin admin = getDataContext().getAdmin()) {
+                    assertFalse(admin.tableExists(TableName.valueOf(TABLE_NAME)));
+                } catch (IOException e) {
+                    fail("Should not an exception checking if the table exists");
+                }
             }
         }
     }
@@ -245,8 +240,8 @@ public abstract class HBaseUpdateCallbackTest extends HBaseTestCase {
 
     /**
      * Warn that the test(method) of a class is not executed, because the test-file hasn't been set.
-     * See {@link HBaseTestCase#getPropertyFilePath} 
-     * @param className 
+     * See {@link HBaseTestCase#getPropertyFilePath}
+     * @param className
      * @param methodName
      */
     protected void warnAboutANotExecutedTest(String className, String methodName) {

--- a/hbase/src/test/java/org/apache/metamodel/hbase/InsertRowTest.java
+++ b/hbase/src/test/java/org/apache/metamodel/hbase/InsertRowTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.hbase;
 
+import static org.junit.Assert.*;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -25,362 +27,300 @@ import java.util.List;
 
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.schema.MutableTable;
+import org.junit.Test;
 
 public class InsertRowTest extends HBaseUpdateCallbackTest {
 
     /**
      * Check if inserting into a table is supported
+     *
      * @throws IOException
      */
+    @Test
     public void testInsertSupported() throws IOException {
-        if (isConfigured()) {
-            assertTrue(getUpdateCallback().isInsertSupported());
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
-        }
+        assertTrue(getUpdateCallback().isInsertSupported());
     }
 
     /**
      * Using only the table parameter, should throw an exception
+     *
      * @throws IOException
      */
+    @Test
     public void testOnlyUsingTableParameter() throws IOException {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                getUpdateCallback().insertInto(existingTable);
-                fail("Should get an exception that this method is not supported");
-            } catch (UnsupportedOperationException e) {
-                assertEquals("We need an explicit list of columns when inserting into an HBase table.", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            getUpdateCallback().insertInto(existingTable);
+            fail("Should get an exception that this method is not supported");
+        } catch (UnsupportedOperationException e) {
+            assertEquals("We need an explicit list of columns when inserting into an HBase table.", e.getMessage());
         }
     }
 
     /**
      * Having the table type wrong, should throw an exception
+     *
      * @throws IOException
      */
+    @Test
     public void testWrongTableType() throws IOException {
-        if (isConfigured()) {
-            final MutableTable mutableTable = new MutableTable();
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
-                getUpdateCallback().insertInto(mutableTable, columns);
-                fail("Should get an exception that the type of the table is wrong.");
-            } catch (IllegalArgumentException e) {
-                assertEquals("Not an HBase table: " + mutableTable, e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        final MutableTable mutableTable = new MutableTable();
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
+            getUpdateCallback().insertInto(mutableTable, columns);
+            fail("Should get an exception that the type of the table is wrong.");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Not an HBase table: " + mutableTable, e.getMessage());
         }
     }
 
     /**
      * Having the columns parameter null at the updateCallBack, should throw an exception
+     *
      * @throws IOException
      */
+    @Test
     public void testColumnsNullAtUpdateCallBack() throws IOException {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                getUpdateCallback().insertInto(existingTable, null);
-                fail("Should get an exception that the columns list is null.");
-            } catch (IllegalArgumentException e) {
-                assertEquals("The hbaseColumns list is null or empty", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            getUpdateCallback().insertInto(existingTable, null);
+            fail("Should get an exception that the columns list is null.");
+        } catch (IllegalArgumentException e) {
+            assertEquals("The hbaseColumns list is null or empty", e.getMessage());
         }
     }
 
     /**
      * Having the columns parameter empty at the updateCallBack, should throw an exception
+     *
      * @throws IOException
      */
+    @Test
     public void testColumnsEmptyAtUpdateCallBack() throws IOException {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                getUpdateCallback().insertInto(existingTable, new ArrayList<HBaseColumn>());
-                fail("Should get an exception that the columns list is empty.");
-            } catch (IllegalArgumentException e) {
-                assertEquals("The hbaseColumns list is null or empty", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            getUpdateCallback().insertInto(existingTable, new ArrayList<HBaseColumn>());
+            fail("Should get an exception that the columns list is empty.");
+        } catch (IllegalArgumentException e) {
+            assertEquals("The hbaseColumns list is null or empty", e.getMessage());
         }
     }
 
     /**
      * Having the columns parameter empty at the builder, should throw an exception
+     *
      * @throws IOException
      */
+    @Test
     public void testColumnsEmptyAtBuilder() throws IOException {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                List<HBaseColumn> emptyList = new ArrayList<>();
-                new HBaseRowInsertionBuilder(getUpdateCallback(), existingTable, emptyList);
-                fail("Should get an exception that the columns list is empty.");
-            } catch (IllegalArgumentException e) {
-                assertEquals("The hbaseColumns list is null or empty", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            List<HBaseColumn> emptyList = new ArrayList<>();
+            new HBaseRowInsertionBuilder(getUpdateCallback(), existingTable, emptyList);
+            fail("Should get an exception that the columns list is empty.");
+        } catch (IllegalArgumentException e) {
+            assertEquals("The hbaseColumns list is null or empty", e.getMessage());
         }
     }
 
     /**
      * Using a table that doesn't exist in the schema, should throw an exception
+     *
      * @throws IOException
      */
+    @Test
     public void testTableThatDoesntExist() throws IOException {
-        if (isConfigured()) {
-            final HBaseTable wrongTable = createHBaseTable("NewTableNotInSchema", HBaseDataContext.FIELD_ID, "cf1",
-                    "cf2", null);
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
-                getUpdateCallback().insertInto(wrongTable, columns);
-                fail("Should get an exception that the table isn't in the schema.");
-            } catch (MetaModelException e) {
-                assertEquals("Trying to insert data into table: " + wrongTable.getName() + ", which doesn't exist yet",
-                        e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        final HBaseTable wrongTable = createHBaseTable("NewTableNotInSchema", HBaseDataContext.FIELD_ID, "cf1", "cf2",
+                null);
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
+            getUpdateCallback().insertInto(wrongTable, columns);
+            fail("Should get an exception that the table isn't in the schema.");
+        } catch (MetaModelException e) {
+            assertEquals("Trying to insert data into table: " + wrongTable.getName() + ", which doesn't exist yet", e
+                    .getMessage());
         }
     }
 
     /**
      * If the ID-column doesn't exist in the columns array, then a exception should be thrown
+     *
      * @throws IOException
      */
+    @Test
     public void testIDColumnDoesntExistInColumnsArray() throws IOException {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, null, CF_FOO, CF_BAR);
-                final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
-                getUpdateCallback().insertInto(existingTable, columns);
-                fail("Should get an exception that ID-column doesn't exist.");
-            } catch (MetaModelException e) {
-                assertEquals("The ID-Column was not found", e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, null, CF_FOO, CF_BAR);
+            final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
+            getUpdateCallback().insertInto(existingTable, columns);
+            fail("Should get an exception that ID-column doesn't exist.");
+        } catch (MetaModelException e) {
+            assertEquals("The ID-Column was not found", e.getMessage());
         }
     }
 
     /**
      * If the column family doesn't exist in the table (wrong columnFamily), then a exception should be thrown
+     *
      * @throws IOException
      */
+    @Test
     public void testColumnFamilyDoesntExistsBecauseItsNull() throws IOException {
-        if (isConfigured()) {
-            final String wrongColumnFamily = "wrongColumnFamily";
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
-                final HBaseTable wrongTable = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        wrongColumnFamily, null);
-                getUpdateCallback().insertInto(wrongTable, columns);
-                fail("Should get an exception that the columnFamily doesn't exist.");
-            } catch (MetaModelException e) {
-                assertEquals(String.format("ColumnFamily: %s doesn't exist in the schema of the table",
-                        wrongColumnFamily), e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        final String wrongColumnFamily = "wrongColumnFamily";
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
+            final HBaseTable wrongTable = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    wrongColumnFamily, null);
+            getUpdateCallback().insertInto(wrongTable, columns);
+            fail("Should get an exception that the columnFamily doesn't exist.");
+        } catch (MetaModelException e) {
+            assertEquals(String.format("ColumnFamily: %s doesn't exist in the schema of the table", wrongColumnFamily),
+                    e.getMessage());
         }
     }
 
     /**
      * If the column family doesn't exist in the table (new columnFamily), then a exception should be thrown
+     *
      * @throws IOException
      */
+    @Test
     public void testColumnFamilyDoesntExistsBecauseItsNew() throws IOException {
-        if (isConfigured()) {
-            final String wrongColumnFamily = "newColumnFamily";
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
-                final HBaseTable wrongTable = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR,
-                        wrongColumnFamily);
-                getUpdateCallback().insertInto(wrongTable, columns);
-                fail("Should get an exception that the columnFamily doesn't exist.");
-            } catch (MetaModelException e) {
-                assertEquals(String.format("ColumnFamily: %s doesn't exist in the schema of the table",
-                        wrongColumnFamily), e.getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        final String wrongColumnFamily = "newColumnFamily";
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
+            final HBaseTable wrongTable = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR,
+                    wrongColumnFamily);
+            getUpdateCallback().insertInto(wrongTable, columns);
+            fail("Should get an exception that the columnFamily doesn't exist.");
+        } catch (MetaModelException e) {
+            assertEquals(String.format("ColumnFamily: %s doesn't exist in the schema of the table", wrongColumnFamily),
+                    e.getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the tableName null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithTableNameNull() {
-        if (isConfigured()) {
-            try {
-                final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromRow(row));
-                final Object[] values = new String[] { "Values" };
-                new HBaseClient(getDataContext().getConnection()).insertRow(null, columns, values, 0);
-                fail("Should get an exception that tableName is null");
-            } catch (IllegalArgumentException e) {
-                assertEquals(
-                        "Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
-                                .getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
+            final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromRow(row));
+            final Object[] values = new String[] { "Values" };
+            new HBaseClient(getDataContext().getConnection()).insertRow(null, columns, values, 0);
+            fail("Should get an exception that tableName is null");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
+                    .getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the columns null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithColumnsNull() {
-        if (isConfigured()) {
-            try {
-                final Object[] values = new String[] { "Values" };
-                new HBaseClient(getDataContext().getConnection()).insertRow("tableName", null, values, 0);
-                fail("Should get an exception that columns is null");
-            } catch (IllegalArgumentException e) {
-                assertEquals(
-                        "Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
-                                .getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final Object[] values = new String[] { "Values" };
+            new HBaseClient(getDataContext().getConnection()).insertRow("tableName", null, values, 0);
+            fail("Should get an exception that columns is null");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
+                    .getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the values null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithValuesNull() {
-        if (isConfigured()) {
-            try {
-                final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromRow(row));
-                new HBaseClient(getDataContext().getConnection()).insertRow(table.getName(), columns, null, 0);
-                fail("Should get an exception that values is null");
-            } catch (IllegalArgumentException e) {
-                assertEquals(
-                        "Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
-                                .getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
+            final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromRow(row));
+            new HBaseClient(getDataContext().getConnection()).insertRow(table.getName(), columns, null, 0);
+            fail("Should get an exception that values is null");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
+                    .getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the indexOfIdColumn out of bounce, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithIndexOfIdColumnOutOfBounce() {
-        if (isConfigured()) {
-            try {
-                final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromRow(row));
-                final Object[] values = new String[] { "Values" };
-                new HBaseClient(getDataContext().getConnection()).insertRow(table.getName(), columns, values, 10);
-                fail("Should get an exception that the indexOfIdColumn is incorrect");
-            } catch (IllegalArgumentException e) {
-                assertEquals(
-                        "Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
-                                .getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
+            final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromRow(row));
+            final Object[] values = new String[] { "Values" };
+            new HBaseClient(getDataContext().getConnection()).insertRow(table.getName(), columns, values, 10);
+            fail("Should get an exception that the indexOfIdColumn is incorrect");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
+                    .getMessage());
         }
     }
 
     /**
      * Creating a HBaseClient with the rowKey null, should throw a exception
      */
+    @Test
     public void testCreatingTheHBaseClientWithRowKeyNull() {
-        if (isConfigured()) {
-            try {
-                final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromRow(row));
-                final Object[] values = new String[] { null };
-                new HBaseClient(getDataContext().getConnection()).insertRow(table.getName(), columns, values, 0);
-                fail("Should get an exception that the indexOfIdColumn is incorrect");
-            } catch (IllegalArgumentException e) {
-                assertEquals(
-                        "Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
-                                .getMessage());
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable table = createHBaseTable(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR, null);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(table, HBaseDataContext.FIELD_ID, CF_FOO, CF_BAR);
+            final HBaseColumn[] columns = convertToHBaseColumnsArray(getHBaseColumnsFromRow(row));
+            final Object[] values = new String[] { null };
+            new HBaseClient(getDataContext().getConnection()).insertRow(table.getName(), columns, values, 0);
+            fail("Should get an exception that the indexOfIdColumn is incorrect");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Can't insert a row without having (correct) tableName, columns, values or indexOfIdColumn", e
+                    .getMessage());
         }
     }
 
     /**
      * Goodflow. Using an existing table and columns, should work
      */
+    @Test
     public void testInsertIntoWithoutExecute() {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
-                getUpdateCallback().insertInto(existingTable, columns);
-            } catch (Exception e) {
-                fail("No exception should be thrown, when inserting into an existing table.");
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
+            getUpdateCallback().insertInto(existingTable, columns);
+        } catch (Exception e) {
+            fail("No exception should be thrown, when inserting into an existing table.");
         }
     }
 
@@ -413,27 +353,22 @@ public class InsertRowTest extends HBaseUpdateCallbackTest {
     /**
      * Goodflow. Inserting a row succesfully (with values set)
      */
+    @Test
     public void testInsertingSuccesfully() {
-        if (isConfigured()) {
-            try {
-                final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
-                        CF_BAR);
-                final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID,
-                        CF_FOO, CF_BAR);
-                final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
+        try {
+            final HBaseTable existingTable = createAndAddTableToDatastore(TABLE_NAME, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final LinkedHashMap<HBaseColumn, Object> row = createRow(existingTable, HBaseDataContext.FIELD_ID, CF_FOO,
+                    CF_BAR);
+            final List<HBaseColumn> columns = getHBaseColumnsFromRow(row);
 
-                checkRows(false);
-                final HBaseRowInsertionBuilder rowInsertionBuilder = getUpdateCallback().insertInto(existingTable,
-                        columns);
-                setValuesInInsertionBuilder(row, rowInsertionBuilder);
-                rowInsertionBuilder.execute();
-                checkRows(true);
-            } catch (Exception e) {
-                fail("No exception should be thrown, when inserting with values.");
-            }
-        } else {
-            warnAboutANotExecutedTest(getClass().getName(), new Object() {
-            }.getClass().getEnclosingMethod().getName());
+            checkRows(false);
+            final HBaseRowInsertionBuilder rowInsertionBuilder = getUpdateCallback().insertInto(existingTable, columns);
+            setValuesInInsertionBuilder(row, rowInsertionBuilder);
+            rowInsertionBuilder.execute();
+            checkRows(true);
+        } catch (Exception e) {
+            fail("No exception should be thrown, when inserting with values.");
         }
     }
 
@@ -446,5 +381,4 @@ public class InsertRowTest extends HBaseUpdateCallbackTest {
     private static HBaseColumn[] convertToHBaseColumnsArray(List<HBaseColumn> columns) {
         return columns.toArray(new HBaseColumn[columns.size()]);
     }
-
 }


### PR DESCRIPTION
Refactored test so they no longer extends TestCase (and as such are no longer JUnit 3, but JUnit 4 tests) and they use "assumeTrue" to check if they should run or not. This reduces a lot of boiler plate code, because now we don't need to call the "isConfigured" method in each test method.

Also added some extra null check in the code which cleans up after test, because some nullpointer exceptions were thrown when the tests were skipped.